### PR TITLE
pip and performance

### DIFF
--- a/base/src/python.ecmp
+++ b/base/src/python.ecmp
@@ -1,10 +1,10 @@
 [info] 
 name = python
-version = 3.12.4
+version = 3.12.7
 type = src
 license = PSF
 url = https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tar.xz
-sha256 = f6d419a6d8743ab26700801b4908d26d97e8b986e14f95de31b32de2b0e79554
+sha256 = 24887b92e2afd4a2ac602419ad4b596372f67ac9b077190f459aba390faf5550
 
 [description]
 The Python 3 package contains the Python development environment. It is useful for object-oriented programming, writing scripts, prototyping large programs, and developing entire applications. Python is an interpreted computer language. 
@@ -15,11 +15,14 @@ tar xf $NAME-$VERSION.tar.xz
 mv Python-$VERSION python-$VERSION
 
 [install]
+# improves pgo
+export CFLAGS="${CFLAGS/-O2/-O3} -ffat-lto-objects"
 ./configure --prefix=/usr        \
             --enable-shared      \
+            --with-lto \
             --with-system-expat  \
             --enable-optimizations \
-	    --disable-test-modules
+	    --with-ensurepip=install
 
 make
 make DESTDIR=$SOVIET_BUILD_DIR install


### PR DESCRIPTION
- version bump
- actually install pip
- some compile optimizations (liberated from Arch pkgbuild)

note that there's a zlib push as well - this build will fail without re-installing zlib first