### PR TITLE
fixes for python, remove unneeded code

### DIFF
--- a/base/src/zlib.ecmp
+++ b/base/src/zlib.ecmp
@@ -13,8 +13,7 @@ curl -o $NAME-$VERSION.tar.gz $URL
 tar -xf $NAME-$VERSION.tar.gz
 
 [install]
+export CFLAGS="$CFLAGS -fPIC"
 ./configure --prefix=/usr
 make 
 make DESTDIR=$SOVIET_BUILD_DIR install
-ln -sfv ../../lib/$(readlink $SOVIET_BUILD_DIR/usr/lib/libz.so) $SOVIET_BUILD_DIR/usr/lib/libz.so
-

--- a/base/src/zlib.ecmp
+++ b/base/src/zlib.ecmp
@@ -17,3 +17,5 @@ export CFLAGS="$CFLAGS -fPIC"
 ./configure --prefix=/usr
 make 
 make DESTDIR=$SOVIET_BUILD_DIR install
+# from LFS: remove a usless static lib
+rm $SOVIET_BUILD_DIR/usr/lib/libz.a


### PR DESCRIPTION
- python's lto will fail unless zlib is compiled with -fPIC (?)
- the last line in the ecmp isn't necessary - the install creates this file on it's own.
- added a line to remove a static lib that isn't used.